### PR TITLE
Fix path handling issues caused by VBoxManage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Build the app using:
 
 And install it with:
 
-    $ vagrant plugin install vagrant-ignition-0.0.1.gem
+    $ vagrant plugin install vagrant-ignition-0.0.2.gem
 
 ## Usage
 To use this plugin, a couple of config options must be set in a project's Vagrantfile config section.
@@ -22,9 +22,9 @@ Options:
 
 `config.ignition.config_obj`: Set equal to `config.vm.provider :virtualbox`
 
-`config.ignition.config_img`: Set to desired location of generated image (optional)
+`config.ignition.drive_root`: Set to desired root directory of generated config drive (optional)
 
-`config.ignition.config_vmdk`: Set to desired location of generated vmdk (optional)
+`config.ignition.drive_name`: Set to desired filename of generated config drive (optional)
 
 `config.ignition.hostname`: Set to desired hostname of the machine (optional)
 

--- a/lib/vagrant-ignition/action/merge_ignition.rb
+++ b/lib/vagrant-ignition/action/merge_ignition.rb
@@ -59,7 +59,7 @@ def merge_ignition(ignition_path, hostname, ip, env)
     config[:passwd][:users] += [ssh_entry()]
   end
 
-  File.open(ignition_path + ".merged","w") do |f|
+  File.open(ignition_path + ".merged","wb") do |f|
     f.write(config.to_json)
   end
 end

--- a/lib/vagrant-ignition/action/setup_ignition.rb
+++ b/lib/vagrant-ignition/action/setup_ignition.rb
@@ -17,16 +17,16 @@ module VagrantPlugins
           end
 
           config_path = env[:machine].config.ignition.path
-          config_vmdk = env[:machine].config.ignition.config_vmdk
-          config_img = env[:machine].config.ignition.config_img
+          drive_name = env[:machine].config.ignition.drive_name
+          drive_root = env[:machine].config.ignition.drive_root
 
           hostname = env[:machine].config.ignition.hostname
           ip = env[:machine].config.ignition.ip
 
-          vmdk_gen(config_path, config_vmdk, config_img, hostname, ip, env)
+          vmdk_gen(config_path, drive_name, drive_root, hostname, ip, env)
 
           env[:machine].ui.info "Configuring Ignition Config Drive"
-          env[:machine].provider.driver.execute("storageattach", "#{env[:machine].id}", "--storagectl", "IDE Controller", "--device", "0", "--port", "1", "--type", "hdd", "--medium", "#{config_vmdk}")
+          env[:machine].provider.driver.execute("storageattach", "#{env[:machine].id}", "--storagectl", "IDE Controller", "--device", "0", "--port", "1", "--type", "hdd", "--medium", "#{File.join(drive_root, (drive_name + ".vmdk"))}")
 
           # Continue through the middleware chain
           @app.call(env)

--- a/lib/vagrant-ignition/action/vmdk_gen.rb
+++ b/lib/vagrant-ignition/action/vmdk_gen.rb
@@ -2,7 +2,14 @@
 require_relative 'merge_ignition'
 require_relative 'IgnitionDiskGenerator'
 
-def vmdk_gen(ignition_path, vmdk_name, config_drive, hostname, ip, env)
+def vmdk_gen(ignition_path, drive_name, drive_root, hostname, ip, env)
+  # This ensures changes the directory to the drive_root so the img and
+  # vmdk can be generated in the same directory as well as avoid some
+  # path name bugs
+  orig_dir = Dir.pwd
+  Dir.chdir(drive_root)
+  vmdk_name = drive_name + ".vmdk"
+  config_drive = drive_name + ".img"
   merge_ignition(ignition_path, hostname, ip, env)
   if !ignition_path.nil?
     IgnitionDiskGenerator.create_disk(ignition_path + ".merged", config_drive)
@@ -14,4 +21,5 @@ def vmdk_gen(ignition_path, vmdk_name, config_drive, hostname, ip, env)
     File.delete(vmdk_name)
   end
   env[:machine].provider.driver.execute("internalcommands", "createrawvmdk", "-filename", "#{vmdk_name}", "-rawdisk", "#{config_drive}")
+  Dir.chdir(orig_dir)
 end

--- a/lib/vagrant-ignition/config.rb
+++ b/lib/vagrant-ignition/config.rb
@@ -4,8 +4,8 @@ module VagrantPlugins
       attr_accessor :enabled
       attr_accessor :path
       attr_accessor :config_obj
-      attr_accessor :config_img
-      attr_accessor :config_vmdk
+      attr_accessor :drive_name
+      attr_accessor :drive_root
       attr_accessor :hostname
       attr_accessor :ip
 
@@ -13,8 +13,8 @@ module VagrantPlugins
         @enabled     = UNSET_VALUE
         @path        = UNSET_VALUE
         @config_obj  = UNSET_VALUE
-        @config_img  = UNSET_VALUE
-        @config_vmdk = UNSET_VALUE
+        @drive_name  = UNSET_VALUE
+        @drive_root  = UNSET_VALUE
         @hostname    = UNSET_VALUE
         @ip          = UNSET_VALUE
       end
@@ -22,8 +22,8 @@ module VagrantPlugins
       def finalize!
         @enabled     = false         if @enabled     == UNSET_VALUE
         @path        = nil           if @path        == UNSET_VALUE
-        @config_img  = "config.img"  if @config_img  == UNSET_VALUE
-        @config_vmdk = "config.vmdk" if @config_vmdk == UNSET_VALUE
+        @drive_name  = "config"      if @drive_name  == UNSET_VALUE
+        @drive_root  = "./"          if @drive_path  == UNSET_VALUE
         @hostname    = nil           if @hostname    == UNSET_VALUE
         @ip          = nil           if @ip          == UNSET_VALUE
       end

--- a/vagrant-ignition.gemspec
+++ b/vagrant-ignition.gemspec
@@ -5,7 +5,7 @@ require "vagrant-ignition/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "vagrant-ignition"
-  spec.version       = "0.0.1"
+  spec.version       = "0.0.2"
   spec.authors       = ["Alexander Pavel", "Alex Crawford"]
   spec.email         = ["alex.pavel@coreos.com", "alex.crawford@coreos.com"]
 


### PR DESCRIPTION
Due to VBoxManage not being able to mount vmdk disks pointing to a backing storage using absolute paths, there needs to be a workaround for when the vmdk and img are not it the project root. This makes sure that the img and vmdk are in the same directory, preventing problems that may occur otherwise on Windows.

This required a change to the config spec. The README.md was updated accordingly.

This also makes sure that all files are written with LF line endings and bumps the version to 0.0.2