### PR TITLE
config.rb: fix incorrect drive_root line

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Build the app using:
 
 And install it with:
 
-    $ vagrant plugin install vagrant-ignition-0.0.2.gem
+    $ vagrant plugin install vagrant-ignition-0.0.3.gem
 
 ## Usage
 To use this plugin, a couple of config options must be set in a project's Vagrantfile config section.

--- a/lib/vagrant-ignition/config.rb
+++ b/lib/vagrant-ignition/config.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
         @enabled     = false         if @enabled     == UNSET_VALUE
         @path        = nil           if @path        == UNSET_VALUE
         @drive_name  = "config"      if @drive_name  == UNSET_VALUE
-        @drive_root  = "./"          if @drive_path  == UNSET_VALUE
+        @drive_root  = "./"          if @drive_root  == UNSET_VALUE
         @hostname    = nil           if @hostname    == UNSET_VALUE
         @ip          = nil           if @ip          == UNSET_VALUE
       end

--- a/vagrant-ignition.gemspec
+++ b/vagrant-ignition.gemspec
@@ -5,7 +5,7 @@ require "vagrant-ignition/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "vagrant-ignition"
-  spec.version       = "0.0.2"
+  spec.version       = "0.0.3"
   spec.authors       = ["Alexander Pavel", "Alex Crawford"]
   spec.email         = ["alex.pavel@coreos.com", "alex.crawford@coreos.com"]
 


### PR DESCRIPTION
A typo in the finalize method caused drive_root to not be set correctly
when drive_root was not explicitly set.