### PR TITLE
merge_ignition: support coreos-metadata override

### DIFF
--- a/lib/vagrant-ignition/action/merge_ignition.rb
+++ b/lib/vagrant-ignition/action/merge_ignition.rb
@@ -12,6 +12,10 @@ def ip_entry(ip)
   {name: "00-eth1.network", contents: "[Match]\nName=eth1\n\n[Network]\nAddress=%s" % ip}
 end
 
+def virtualbox_metadata_override(ip)
+  {name: "coreos-metadata.service", dropins: [{name: "20-vagrant-provider-override.conf", contents: "[Service]\nEnvironment=COREOS_METADATA_OPT_PROVIDER=--provider=vagrant-virtualbox"}]}
+end
+
 # Vagrant insecure key
 VAGRANT_INSECURE_KEY = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
 
@@ -47,6 +51,9 @@ def merge_ignition(ignition_path, hostname, ip, env)
     config[:networkd] ||= {:units => []}
     config[:networkd][:units] ||= []
     config[:networkd][:units] += [ip_entry(ip)]
+    config[:systemd] ||= {:units => []}
+    config[:systemd][:units] ||= []
+    config[:systemd][:units] += [virtualbox_metadata_override(ip)]
   end
 
   # Handle ssh key


### PR DESCRIPTION
This uses coreos-metadata overrides to specify the private IP to
coreos-metadata.

This depends on https://github.com/coreos/coreos-metadata/pull/55 and https://github.com/coreos/coreos-metadata/pull/56. Also, it might be a good idea to wait until https://github.com/coreos/vagrant-ignition/pull/5 is merged so we can add vmware metadata support to this as well