### PR TITLE
lib: added insert_insecure_key option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Build the app using:
 
 And install it with:
 
-    $ vagrant plugin install vagrant-ignition-0.0.3.gem
+    $ vagrant plugin install vagrant-ignition-0.0.4.gem
 
 ## Usage
 To use this plugin, a couple of config options must be set in a project's Vagrantfile config section.
@@ -29,6 +29,8 @@ Options:
 `config.ignition.hostname`: Set to desired hostname of the machine (optional)
 
 `config.ignition.ip`: Set to desired ip of eth1 (only applies if a private network is being created)
+
+`config.ignition.insert_insecure_key`: Set to false if you want to avoid inserting the Vagrant insecure key (you should add your own key, otherwise you won't be able to login via ssh)
 
 ## Contributing
 

--- a/lib/vagrant-ignition/action/setup_ignition.rb
+++ b/lib/vagrant-ignition/action/setup_ignition.rb
@@ -22,8 +22,9 @@ module VagrantPlugins
 
           hostname = env[:machine].config.ignition.hostname
           ip = env[:machine].config.ignition.ip
+          insert_insecure_key = env[:machine].config.ignition.insert_insecure_key
 
-          vmdk_gen(config_path, drive_name, drive_root, hostname, ip, env)
+          vmdk_gen(config_path, drive_name, drive_root, hostname, ip, env, insert_insecure_key)
 
           env[:machine].ui.info "Configuring Ignition Config Drive"
           env[:machine].provider.driver.execute("storageattach", "#{env[:machine].id}", "--storagectl", "IDE Controller", "--device", "0", "--port", "1", "--type", "hdd", "--medium", "#{File.join(drive_root, (drive_name + ".vmdk"))}")

--- a/lib/vagrant-ignition/action/vmdk_gen.rb
+++ b/lib/vagrant-ignition/action/vmdk_gen.rb
@@ -2,7 +2,7 @@
 require_relative 'merge_ignition'
 require_relative 'IgnitionDiskGenerator'
 
-def vmdk_gen(ignition_path, drive_name, drive_root, hostname, ip, env)
+def vmdk_gen(ignition_path, drive_name, drive_root, hostname, ip, env, insert_insecure_key)
   # This ensures changes the directory to the drive_root so the img and
   # vmdk can be generated in the same directory as well as avoid some
   # path name bugs
@@ -10,7 +10,7 @@ def vmdk_gen(ignition_path, drive_name, drive_root, hostname, ip, env)
   Dir.chdir(drive_root)
   vmdk_name = drive_name + ".vmdk"
   config_drive = drive_name + ".img"
-  merge_ignition(ignition_path, hostname, ip, env)
+  merge_ignition(ignition_path, hostname, ip, env, insert_insecure_key)
   if !ignition_path.nil?
     IgnitionDiskGenerator.create_disk(ignition_path + ".merged", config_drive)
   else

--- a/lib/vagrant-ignition/config.rb
+++ b/lib/vagrant-ignition/config.rb
@@ -8,24 +8,27 @@ module VagrantPlugins
       attr_accessor :drive_root
       attr_accessor :hostname
       attr_accessor :ip
+      attr_accessor :insert_insecure_key
 
       def initialize
-        @enabled     = UNSET_VALUE
-        @path        = UNSET_VALUE
-        @config_obj  = UNSET_VALUE
-        @drive_name  = UNSET_VALUE
-        @drive_root  = UNSET_VALUE
-        @hostname    = UNSET_VALUE
-        @ip          = UNSET_VALUE
+        @enabled              = UNSET_VALUE
+        @path                 = UNSET_VALUE
+        @config_obj           = UNSET_VALUE
+        @drive_name           = UNSET_VALUE
+        @drive_root           = UNSET_VALUE
+        @hostname             = UNSET_VALUE
+        @ip                   = UNSET_VALUE
+        @insert_insecure_key  = UNSET_VALUE
       end
 
       def finalize!
-        @enabled     = false         if @enabled     == UNSET_VALUE
-        @path        = nil           if @path        == UNSET_VALUE
-        @drive_name  = "config"      if @drive_name  == UNSET_VALUE
-        @drive_root  = "./"          if @drive_root  == UNSET_VALUE
-        @hostname    = nil           if @hostname    == UNSET_VALUE
-        @ip          = nil           if @ip          == UNSET_VALUE
+        @enabled              = false         if @enabled             == UNSET_VALUE
+        @path                 = nil           if @path                == UNSET_VALUE
+        @drive_name           = "config"      if @drive_name          == UNSET_VALUE
+        @drive_root           = "./"          if @drive_root          == UNSET_VALUE
+        @hostname             = nil           if @hostname            == UNSET_VALUE
+        @ip                   = nil           if @ip                  == UNSET_VALUE
+        @insert_insecure_key  = true          if @insert_insecure_key == UNSET_VALUE
       end
     end
   end

--- a/vagrant-ignition.gemspec
+++ b/vagrant-ignition.gemspec
@@ -5,7 +5,7 @@ require "vagrant-ignition/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "vagrant-ignition"
-  spec.version       = "0.0.3"
+  spec.version       = "0.0.4"
   spec.authors       = ["Alexander Pavel", "Alex Crawford"]
   spec.email         = ["alex.pavel@coreos.com", "alex.crawford@coreos.com"]
 


### PR DESCRIPTION
Allowing users to avoid insertion of the VAGRANT_INSECURE_KEY.
Current behaviour is preserved by the default value.